### PR TITLE
Fix DESCRIPTION file

### DIFF
--- a/masteringmetrics/DESCRIPTION
+++ b/masteringmetrics/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: masteringmetrics
 Title: Datasets for Mastering 'Metrics
 Version: 0.1
-Authors@R: c(person("Jeffrey", "Arnold", , "jeffrey.arnold@gmail.com", c("aut", "cre"))
+Authors@R: c(person("Jeffrey", "Arnold", , "jeffrey.arnold@gmail.com", c("aut", "cre")))
 Description: Dependencies for R code to replicate the analyses
   in Angrist and Pischke, "Mastering 'Metrics".
 Depends: R (>= 3.4.0)


### PR DESCRIPTION
Fixes #2

It was missing a paren, so the format was incorrect.